### PR TITLE
Add Terms Of Use page with next button, and successfully bind an ORCiD

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-use": "^17.3.1",
     "sass": "^1.30.0",
     "source-map-explorer": "^2.5.2",
-    "synapse-react-client": "2.1.19",
+    "synapse-react-client": "2.1.20",
     "typescript": "4.3.5"
   },
   "jest": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import './App.css'
 import AppInitializer from './AppInitializer'
-import Versions from './Versions'
 import { SynapseContextConsumer, SynapseContextType } from 'synapse-react-client/dist/utils/SynapseContext'
 import {
   BrowserRouter as Router,
@@ -14,8 +13,8 @@ import LoginPage from './LoginPage'
 import { RegisterAccount1 } from 'components/RegisterAccount1'
 import { SynapseComponents } from 'synapse-react-client'
 import { RegisterAccount2 } from 'components/RegisterAccount2'
-import TermsAndConditions from 'synapse-react-client/dist/containers/TermsAndConditions'
 import { ORCiDButton } from 'components/ORCiDButton'
+import { TermsOfUsePage } from 'components/TermsOfUsePage'
 
 const App: React.FC = () => {
   return (
@@ -59,11 +58,7 @@ const App: React.FC = () => {
                             </>
                           )
                         } else if (path === '/authenticated/signTermsOfUse') {
-                          return (
-                            <>
-                              <TermsAndConditions onFormChange={(completed:boolean) => { console.log("is the form completed?", completed) }} />
-                            </>
-                          )
+                          return <TermsOfUsePage />
                        } else if (path === '/authenticated/myaccount') {
                         return (
                           <>
@@ -91,7 +86,6 @@ const App: React.FC = () => {
             </AppInitializer>
           </Router>
         </>
-      <Versions />
       <SynapseComponents.SynapseToastContainer />
     </div>
   );

--- a/src/AppInitializer.tsx
+++ b/src/AppInitializer.tsx
@@ -5,6 +5,7 @@ import { withCookies, ReactCookieProps } from 'react-cookie'
 import { SynapseContextProvider } from 'synapse-react-client/dist/utils/SynapseContext'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import { UserProfile } from 'synapse-react-client/dist/utils/synapseTypes'
+import { getSearchParam } from 'URLUtils'
 
 export type AppInitializerState = {
   token: string
@@ -35,6 +36,13 @@ class AppInitializer extends React.Component<Props, AppInitializerState> {
         hasCalledGetSession: true,
       })
     })
+  }
+
+  initSourceAppId = () => {
+    const appId = getSearchParam('appId')
+    if (appId) {
+      localStorage.setItem('sourceAppId', appId)
+    }
   }
 
   getSession = async () => {
@@ -76,6 +84,7 @@ class AppInitializer extends React.Component<Props, AppInitializerState> {
   }
 
   componentDidMount() {
+    this.initSourceAppId()
     this.getSession()
     SynapseClient.detectSSOCode('/register1',
       (err) => {

--- a/src/AppInitializer.tsx
+++ b/src/AppInitializer.tsx
@@ -4,6 +4,7 @@ import { SynapseClient } from 'synapse-react-client'
 import { withCookies, ReactCookieProps } from 'react-cookie'
 import { SynapseContextProvider } from 'synapse-react-client/dist/utils/SynapseContext'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
+import { UserProfile } from 'synapse-react-client/dist/utils/synapseTypes'
 
 export type AppInitializerState = {
   token: string
@@ -11,6 +12,7 @@ export type AppInitializerState = {
   // delay render until get session is called, o.w. theres an uneccessary refresh right
   // after page load
   hasCalledGetSession: boolean
+  userProfile?: UserProfile
 }
 
 type Props = RouteComponentProps & ReactCookieProps
@@ -42,7 +44,16 @@ class AppInitializer extends React.Component<Props, AppInitializerState> {
         this.initAnonymousUserState()
         return
       }
-      this.setState({ token, hasCalledGetSession: true })
+      // verify we can get the current user profile
+      let userProfile = undefined
+      try {
+        userProfile = await SynapseClient.getUserProfile(token)
+      } catch (error:any) {
+        if ((error.reason as string).toLowerCase().includes('terms of use') && window.location.pathname !== '/authenticated/signTermsOfUse' ) {
+          window.location.assign('/authenticated/signTermsOfUse')
+        }
+      }
+      this.setState({ token, userProfile, hasCalledGetSession: true })
     } catch (e) {
       console.error('Error on getSession: ', e)
       // intentionally calling sign out because there token could be stale so we want

--- a/src/components/RegisterAccount1.tsx
+++ b/src/components/RegisterAccount1.tsx
@@ -7,6 +7,7 @@ import { PROVIDERS } from 'synapse-react-client/dist/containers/Login'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import { isAliasAvailable, registerAccountStep1 } from 'synapse-react-client/dist/utils/SynapseClient'
 import { AliasType } from 'synapse-react-client/dist/utils/synapseTypes/Principal/PrincipalServices'
+import SourceApp from './SourceApp'
 
 export type RegisterAccount1Props = {
 }
@@ -82,6 +83,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
 
   return (
     <>
+      <SourceApp />
       <div className="RegisterAccount1 bootstrap-4-backport">
         <div className="GoogleSignUpUI">
           <Typography variant='label'>Choose a username</Typography>

--- a/src/components/SourceApp.tsx
+++ b/src/components/SourceApp.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+export type SourceAppProps = {
+}
+
+/**
+ * This is where the app specific UI will be shown
+ * @param props 
+ * @returns 
+ */
+export const SourceApp = (props: SourceAppProps) => {
+  const sourceAppId = localStorage.getItem('sourceAppId')
+
+  return ( <>
+      {sourceAppId && <p>Source app currently set to {sourceAppId}</p>}
+    </>
+  )
+}
+
+export const getSourceAppRedirectURL = (): string | undefined => {
+  const sourceAppId = localStorage.getItem('sourceAppId')
+  if (!sourceAppId) {
+    return undefined
+  }
+  switch(sourceAppId) {
+    case 'MTB': return 'https://staging.mobiletoolbox.org/'
+    default: return undefined
+  }
+}
+
+export default SourceApp

--- a/src/components/TermsOfUsePage.tsx
+++ b/src/components/TermsOfUsePage.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import {
+  Button,
+} from 'react-bootstrap'
+import { Redirect } from 'react-router-dom'
+import { SynapseClient } from 'synapse-react-client'
+import TermsAndConditions from 'synapse-react-client/dist/containers/TermsAndConditions'
+import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
+import { useSynapseContext } from 'synapse-react-client/dist/utils/SynapseContext'
+
+export type TermsOfUsePageProps = {
+}
+
+export const TermsOfUsePage = (props: TermsOfUsePageProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [isFormComplete, setIsFormComplete] = useState(false)
+  const [isDone, setIsDone] = useState(false)
+  const { accessToken } = useSynapseContext()
+  
+  const onSignTermsOfUse = async (event: React.SyntheticEvent) => {
+    event.preventDefault()
+    setIsLoading(true)
+    try {
+      if(accessToken) {
+        SynapseClient.signSynapseTermsOfUse(accessToken)
+        .then(() => {
+          setIsDone(true)
+        })
+        .catch((err: any) => {
+          displayToast(err.reason as string, 'danger')
+        })
+      }
+    } catch (err:any) {
+      displayToast(err.reason as string, 'danger')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+  return (
+    <>
+      {isDone && <Redirect to='/authenticated/myaccount'/>}
+      <div><TermsAndConditions onFormChange={(completed:boolean) => { setIsFormComplete(completed) }} /></div>
+      <Button
+        variant='primary'
+        onClick={onSignTermsOfUse}
+        type="button"
+        style={{ marginLeft: 20 }}
+        disabled={ isLoading || !isFormComplete }
+      >
+        Next
+      </Button>
+    </>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12414,10 +12414,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synapse-react-client@2.1.19:
-  version "2.1.19"
-  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-2.1.19.tgz#467b58fc86890b8d13167f3aeefab2d1291cab15"
-  integrity sha512-tdLClsnfNyzwJaVGYGkBAcUgLk7Wo3HERb7rF4ivFRQwxb+UmiKAFQjYyjYfXznoMgm5x+5JLngMGlJ6KTqHiw==
+synapse-react-client@2.1.20:
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/synapse-react-client/-/synapse-react-client-2.1.20.tgz#b14bcfefec3dc73e5f3c7d8988a78542ddd2ac71"
+  integrity sha512-mDK9tx7IAu7XDLTCSj3I6WFo0cWZMq+zVrM913VFRKH5flexjOmVb96SoFGO1tdTZK1I4Yyrq6PaqkxsD4RAbQ==
   dependencies:
     "@brainhubeu/react-carousel" "1.19.26"
     "@fortawesome/fontawesome-free" "^5.13.0"


### PR DESCRIPTION
If we detect that the user has not yet signed the ToU during app init, auto redirect to that path.
Is a Draft PR until SRC is updated (which will have the new signSynapseTermsOfUse call)