### PR TITLE
PORTALS-2419: progress on a new account created page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,6 @@
       href="https://fonts.googleapis.com/css?family=Lato"
       rel="stylesheet"
     />
-    <link href="https://www.synapse.org/generated/swc.css" rel="stylesheet" />
     <link
       rel="stylesheet"
       href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import '@mui/styles'
 import { deepmerge } from '@mui/utils'
 import { AppContextConsumer } from 'AppContext'
+import { AccountCreatedPage } from 'components/AccountCreatedPage'
 import { AccountSettings } from 'components/AccountSettings'
 import { CertificationQuiz } from 'components/CertificationQuiz'
 import CookiesNotification from 'components/CookiesNotification'
@@ -115,6 +116,8 @@ const App: React.FC = () => {
                             return <TermsOfUsePage />
                           } else if (path === '/authenticated/myaccount') {
                             return <AccountSettings />
+                          } else if (path === '/authenticated/accountcreated') {
+                            return <AccountCreatedPage />
                           } else if (path === '/authenticated/myprofile') {
                             return <ProfilePage />
                           } else if (

--- a/src/components/AccountCreatedPage.tsx
+++ b/src/components/AccountCreatedPage.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { useSourceApp, SourceAppLogo } from './SourceApp'
+import { Button, Link, Grid } from '@mui/material'
+import { AppContextConsumer } from 'AppContext'
+import { Typography } from 'synapse-react-client'
+import { Link as RouterLink } from 'react-router-dom'
+import SourceAppConfigs from './SourceAppConfigs'
+
+export type AccountCreatedPageProps = {}
+
+export const AccountCreatedPage = (props: AccountCreatedPageProps) => {
+  const sourceApp = useSourceApp()
+  return (
+    <>
+      <AppContextConsumer>
+        {appContext => (
+          <div className="panel-wrapper-bg AccountCreatedPage">
+            <div className="panel-wrapper with-white-panel-bg">
+              <div className="mainContent">
+                <div className="panel-logo logo-wrapper">
+                  <SourceAppLogo />
+                </div>
+                <Typography variant="h5" sx={{ paddingTop: '50px' }}>
+                  Account created
+                </Typography>
+                <Typography
+                  variant="subtitle1"
+                  sx={{ paddingTop: '10px', paddingBottom: '20px' }}
+                >
+                  <strong>Welcome to {sourceApp?.friendlyName}!</strong>
+                </Typography>
+                <p>
+                  You’ve created a Sage Account, which you can use on the{' '}
+                  {sourceApp?.friendlyName}.
+                </p>
+                <p>
+                  For full access to data and other functionality, we’ll need
+                  additional information to verify your identity and certify you
+                  to upload data.
+                </p>
+                <Link
+                  color="primary"
+                  component={RouterLink}
+                  to="/authenticated/validate"
+                  sx={{ paddingTop: '30px' }}
+                >
+                  Start identity verification
+                </Link>
+                <Link
+                  color="primary"
+                  component={RouterLink}
+                  to="/authenticated/certificationquiz"
+                  sx={{ paddingTop: '15px', paddingBottom: '15px' }}
+                >
+                  Get certified for data upload
+                </Link>
+                <Button
+                  type="button"
+                  color="primary"
+                  variant="contained"
+                  sx={{ padding: '10px' }}
+                  onClick={() => {
+                    appContext?.redirectURL &&
+                      window.location.assign(appContext.redirectURL)
+                  }}
+                >
+                  Take me to {sourceApp?.friendlyName}
+                </Button>
+              </div>
+              <div className={'panel-right'}>
+                <div className={'panel-right-text'}>
+                  <Typography variant="subtitle1">
+                    Your <strong>Sage Account</strong> can also be used to
+                    access all these resources.
+                  </Typography>
+                  <Grid container spacing={5} mx={{ paddingTop: '20px' }}>
+                    {SourceAppConfigs.map(config => {
+                      if (config.appId != sourceApp?.appId) {
+                        return (
+                          <Grid item xs={6} className="sourceAppItem">
+                            <a href={config.appURL}>{config.logo}</a>
+                          </Grid>
+                        )
+                      } else {
+                        return <></>
+                      }
+                    })}
+                  </Grid>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </AppContextConsumer>
+    </>
+  )
+}

--- a/src/components/RegisterAccount1.tsx
+++ b/src/components/RegisterAccount1.tsx
@@ -8,7 +8,7 @@ import {
   registerAccountStep1,
 } from 'synapse-react-client/dist/utils/SynapseClient'
 import { AliasType } from 'synapse-react-client/dist/utils/synapseTypes/Principal/PrincipalServices'
-import { getCurrentSourceApp, SourceAppLogo } from './SourceApp'
+import { useSourceApp, SourceAppLogo } from './SourceApp'
 import { Link } from 'react-router-dom'
 import { EmailConfirmationPage } from './EmailConfirmationPage'
 import { Button, IconButton, Link as MuiLink } from '@mui/material'
@@ -29,12 +29,7 @@ export const RegisterAccount1 = (props: RegisterAccount1Props) => {
   const [email, setEmail] = useState('')
   const [username, setUsername] = useState('')
   const [page, setPage] = useState(Pages.CHOOSE_REGISTRATION)
-  const [sourceAppName, setSourceAppName] = useState<string>()
-
-  React.useEffect(() => {
-    const source = getCurrentSourceApp()
-    setSourceAppName(source?.friendlyName)
-  }, [])
+  const sourceAppName = useSourceApp()?.friendlyName
 
   const buttonSx = {
     width: '100%',

--- a/src/components/SourceApp.tsx
+++ b/src/components/SourceApp.tsx
@@ -16,12 +16,12 @@ export const SourceApp = (props: SourceAppProps) => {
   const { isAccountCreationTextVisible = false } = props
   return (
     <>
-      <div className="SourceAppLogo">{getCurrentSourceApp()?.logo}</div>
+      <div className="SourceAppLogo">{useSourceApp()?.logo}</div>
       {isAccountCreationTextVisible && (
         <div>
           <p>
             A Sage account is required to log into{' '}
-            {getCurrentSourceApp()?.friendlyName}.
+            {useSourceApp()?.friendlyName}.
           </p>
           <p>Create an account to get started.</p>
         </div>
@@ -31,28 +31,28 @@ export const SourceApp = (props: SourceAppProps) => {
 }
 
 export const SourceAppLogo = () => {
-  return <div className="SourceAppLogo">{getCurrentSourceApp()?.logo}</div>
+  return <div className="SourceAppLogo">{useSourceApp()?.logo}</div>
 }
 
 export const SourceAppDescription = () => {
   return (
     <Typography className="description" variant="body1">
-      {getCurrentSourceApp()?.description}
+      {useSourceApp()?.description}
     </Typography>
   )
 }
 
-export const getCurrentSourceApp = (): SourceAppConfig | undefined => {
+export const useSourceApp = (): SourceAppConfig | undefined => {
   const sourceAppId = localStorage.getItem('sourceAppId')
   return SourceAppConfigs.find(config => config.appId === sourceAppId)
 }
 
 export const getSourceAppURL = (): string => {
-  return getCurrentSourceApp()?.appURL ?? 'https://sagebionetworks.org/'
+  return useSourceApp()?.appURL ?? 'https://sagebionetworks.org/'
 }
 
 export const getSourceAppTheme = (): DeprecatedThemeOptions | undefined => {
-  return getCurrentSourceApp()?.theme
+  return useSourceApp()?.theme
 }
 
 export default SourceApp

--- a/src/components/TermsOfUsePage.tsx
+++ b/src/components/TermsOfUsePage.tsx
@@ -4,7 +4,7 @@ import IconSvg from 'synapse-react-client/dist/containers/IconSvg'
 import TermsAndConditions from 'synapse-react-client/dist/containers/TermsAndConditions'
 import { displayToast } from 'synapse-react-client/dist/containers/ToastMessage'
 import { useSynapseContext } from 'synapse-react-client/dist/utils/SynapseContext'
-import { getCurrentSourceApp, SourceAppLogo } from './SourceApp'
+import { useSourceApp, SourceAppLogo } from './SourceApp'
 import { Button, Link } from '@mui/material'
 
 export type TermsOfUsePageProps = {}
@@ -13,12 +13,8 @@ export const TermsOfUsePage = (props: TermsOfUsePageProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isFormComplete, setIsFormComplete] = useState(false)
   const [isDone, setIsDone] = useState(false)
-  const [sourceAppName, setSourceAppName] = useState<string>()
   const { accessToken } = useSynapseContext()
-  React.useEffect(() => {
-    const source = getCurrentSourceApp()
-    setSourceAppName(source?.friendlyName)
-  }, [])
+  const sourceAppName = useSourceApp()?.friendlyName
 
   const tcAgreement =
     'https://s3.amazonaws.com/static.synapse.org/governance/SageBionetworksSynapseTermsandConditionsofUse.pdf'

--- a/src/style/_AccountCreatedPage.scss
+++ b/src/style/_AccountCreatedPage.scss
@@ -1,0 +1,25 @@
+.AccountCreatedPage {
+  .mainContent {
+    margin: 0 64px;
+    min-height: 640px;
+    button,
+    a {
+      width: 100%;
+      margin: 10px 0px;
+      text-align: center;
+      display: block;
+    }
+    > * {
+      width: 300px;
+    }
+  }
+  .sourceAppItem img {
+    max-height: 50px;
+  }
+  .panel-right-text {
+    margin-top: 100px;
+  }
+  .panel-right-text {
+    margin-top: 100px;
+  }
+}

--- a/src/style/_all.scss
+++ b/src/style/_all.scss
@@ -1,1 +1,3 @@
-@import 'core', 'Navbar', 'Register', 'SourceApp', 'LoginPage', 'AccountSetting', 'ValidationProgress', 'ProfileValidationSteps', 'UnbindORCiD', 'ProfilePage', 'TermsOfUse'
+@import 'core', 'Navbar', 'Register', 'SourceApp', 'LoginPage', 'AccountSetting',
+  'ValidationProgress', 'ProfileValidationSteps', 'UnbindORCiD', 'ProfilePage',
+  'TermsOfUse', 'AccountCreatedPage';


### PR DESCRIPTION
Some of the source app icons need to be updated (to include app name, and to change the native height).  And the new /authenticated/accountcreated route still needs to be linked to.

<img width="1148" alt="Screen Shot 2023-01-18 at 4 22 14 PM" src="https://user-images.githubusercontent.com/1864447/213326654-f62b420f-eec7-4877-a172-bd2a9fd44743.png">
